### PR TITLE
[DEMO PR] feat: Introduce support for RGB and GRB leds

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,4 @@
+[submodule "custom/vesc_pkg"]
+	path = custom/vesc_pkg
+	url = https://github.com/Im0rtality/vesc_pkg.git
+	branch = grb-ws2812-led-support


### PR DESCRIPTION
This demo PR showcases the workflow of contribution to the VESC Project using Docker images & [Dev Containers](https://containers.dev/).

A branch has been created, but branching off from `main` and adding [my branch on fork](https://github.com/Im0rtality/vesc_pkg/compare/main...Im0rtality:vesc_pkg:grb-ws2812-led-support) of `vedderb/vesc_pkg`.

What we get:
1. Automated & reproducible dev environment 
2. Clean PRs without any side files: https://github.com/Im0rtality/vesc_pkg/pull/1/files